### PR TITLE
LCH-6301: Avoid inheriting guzzle Client class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "phpunit/phpunit": "^8",
         "squizlabs/php_codesniffer": "^3.5",
         "php-coveralls/php-coveralls": "^2.4",
-        "drupal/coder": "dev-8.x-3.x"
+        "drupal/coder": "dev-8.x-3.x",
+        "phpspec/prophecy": "1.x-dev"
     }
 }

--- a/src/Client/AcsfClient.php
+++ b/src/Client/AcsfClient.php
@@ -30,27 +30,14 @@ class AcsfClient implements ClientInterface {
   /**
    * AcsfClient constructor.
    *
-   * @param string $username
-   *   Acsf username.
-   * @param string $api_key
-   *   Acsf api key.
    * @param \Psr\Log\LoggerInterface $logger
    *   The symfony console logger.
-   * @param array $config
-   *   Client configuration.
+   * @param \GuzzleHttp\ClientInterface $client
+   *   GuzzleClient instance.
    */
-  public function __construct(string $username, string $api_key, LoggerInterface $logger, array $config = []) {
+  public function __construct(LoggerInterface $logger, ClientInterface $client) {
     $this->logger = $logger;
-
-    $default_conf = [
-      'headers' => [
-        'Content-Type' => 'application/json',
-      ],
-      'auth' => [$username, $api_key],
-    ];
-    $config = array_merge_recursive($default_conf, $config);
-
-    $this->httpClient = AcsfClientFactory::getGuzzleClient($config);
+    $this->httpClient = $client;
   }
 
   /**

--- a/src/Client/AcsfClient.php
+++ b/src/Client/AcsfClient.php
@@ -4,8 +4,11 @@ namespace Acquia\Console\Acsf\Client;
 
 use Acquia\Console\Acsf\Libs\Task\TaskException;
 use Acquia\Console\Acsf\Libs\Task\Tasks;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -13,9 +16,16 @@ use Psr\Log\LoggerInterface;
  *
  * @package Acquia\Console\Acsf\Client
  */
-class AcsfClient extends Client {
+class AcsfClient implements ClientInterface {
 
   use ResponseHandlerTrait;
+
+  /**
+   * GuzzleHttp client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
 
   /**
    * AcsfClient constructor.
@@ -40,7 +50,7 @@ class AcsfClient extends Client {
     ];
     $config = array_merge_recursive($default_conf, $config);
 
-    parent::__construct($config);
+    $this->httpClient = AcsfClientFactory::getGuzzleClient($config);
   }
 
   /**
@@ -171,7 +181,7 @@ class AcsfClient extends Client {
    */
   public function __call($method, $args) {
     try {
-      return parent::__call($method, $args);
+      return $this->httpClient->__call($method, $args);
     }
     catch (\Exception $e) {
       $this->logger->error($e->getMessage());
@@ -209,6 +219,41 @@ class AcsfClient extends Client {
       return new Tasks($tasks);
     }
     throw new TaskException('Tasks cannot be retrieved', TaskException::TASK_RETRIEVAL_ERROR);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function send(RequestInterface $request, array $options = []): ResponseInterface {
+    return $this->httpClient->send($request, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface {
+    return $this->httpClient->sendAsync($request, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function request($method, $uri, array $options = []): ResponseInterface {
+    return $this->httpClient->request($method, $uri, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requestAsync($method, $uri, array $options = []): PromiseInterface {
+    return $this->httpClient->requestAsync($method, $uri, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig($option = NULL) {
+    return $this->httpClient->getConfig($option);
   }
 
 }

--- a/src/Client/AcsfClientFactory.php
+++ b/src/Client/AcsfClientFactory.php
@@ -44,7 +44,15 @@ class AcsfClientFactory {
    *   The instantiated client.
    */
   public function fromCredentials(string $username, string $api_key, string $site_name): AcsfClient {
-    return new AcsfClient($username, $api_key, $this->logger, ['base_uri' => $site_name . '/api/v1/']);
+    $config = [
+      'headers' => [
+        'Content-Type' => 'application/json',
+      ],
+      'auth' => [$username, $api_key],
+      'base_uri' => $site_name . '/api/v1/',
+    ];
+
+    return new AcsfClient($this->logger, self::getGuzzleClient($config));
   }
 
   /**

--- a/src/Client/AcsfClientFactory.php
+++ b/src/Client/AcsfClientFactory.php
@@ -2,6 +2,8 @@
 
 namespace Acquia\Console\Acsf\Client;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -43,6 +45,19 @@ class AcsfClientFactory {
    */
   public function fromCredentials(string $username, string $api_key, string $site_name): AcsfClient {
     return new AcsfClient($username, $api_key, $this->logger, ['base_uri' => $site_name . '/api/v1/']);
+  }
+
+  /**
+   * Creates Guzzle client.
+   *
+   * @param array $config
+   *   Initial data.
+   *
+   * @return \GuzzleHttp\ClientInterface
+   *   GuzzleClient instance.
+   */
+  public static function getGuzzleClient(array $config): ClientInterface {
+    return new Client($config);
   }
 
 }


### PR DESCRIPTION
Issue: https://backlog.acquia.com/browse/LCH-6301
